### PR TITLE
Hack entrypoint to work around Actions setting the working dir

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,5 @@
 #!/bin/sh -l
 
+cd /
+
 go run cmd/oidc-debug.go -audience $1


### PR DESCRIPTION
Since this Action is in a private repository, you must clone it manually first and then call the Action.

However, since you have to clone the repository into an alternate directory, Actions will start the Docker container with the working directory being that of the calling workflow repository.

Example here:
https://github.com/github/ci-hello-world/runs/6396135283?check_suite_focus=true#step:5:47

The workdir is set to `--workdir /github/workspace`.

This doesn't work because the go files are actually in `/`. Since the go files are in fact in `/` we can just cd to that directory.

I believe this worked implicitly within this repository because the go files happened to also be mounted into the working directory Actions was setting.