### PR TITLE
Update exec sponsor

### DIFF
--- a/ownership.yaml
+++ b/ownership.yaml
@@ -7,8 +7,8 @@ ownership:
   description: GitHub Action for Debugging OIDC Claims
   kind: code
   repo: https://github.com/github/actions-oidc-debugger
-  team: github/security-ops
-  maintainer: mrsbworth
+  team: github/sae-iam
+  maintainer: admgc
   exec_sponsor: alexiswales
   sev3:
     issue: https://github.com/github/actions-oidc-debugger/issues

--- a/ownership.yaml
+++ b/ownership.yaml
@@ -9,7 +9,7 @@ ownership:
   repo: https://github.com/github/actions-oidc-debugger
   team: github/security-ops
   maintainer: mrsbworth
-  exec_sponsor: jacobdepriest
+  exec_sponsor: alexiswales
   sev3:
     issue: https://github.com/github/actions-oidc-debugger/issues
     slack: secure-access-engineering


### PR DESCRIPTION
This PR updates the exec sponsor for this repository which is used by the service catalog. Ref: https://github.com/github/secure-access-engineering/issues/9976