### PR TITLE
README: Fix audience string to mention org/repo_owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ jobs:
       - name: Debug OIDC Claims
         uses: ./.github/actions/actions-oidc-debugger
         with:
-          audience: 'https://github.com/github'
+          audience: 'https://github.com/<org|repo_owner>' # 
 ```


### PR DESCRIPTION
Removing the hardcoded audience string which points at `https://github.com/github` to make it clear that `github` substring refers to organisation or repo owner of the repository for which the debugger is used.